### PR TITLE
Fix/certicatedup

### DIFF
--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -227,6 +227,10 @@ static void MqttTask(void *parameter)
                 * 
                 * Ideal solution for this issue should be parallel MQTTS and OTA connection, but currently it's not possible to use two WiFiClientSecure instances
                 * in parallel due to heap issues (consumes large amount of memory) and causes crashes.
+                * 
+                * Update: second instance of WiFiClientSecure has been removed as both MQTTS and OTA are now using the same certificate, OTA cert change code has been removed.
+                * 
+                * 
                 */
                 handleUpdates();
                 //

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -189,6 +189,7 @@ static void MqttTask(void *parameter)
         if (WifiIsConnected())
         {
             //Initalises security certificate
+            wifiClientSecure.setTimeout(12); // timeout argument is defined in seconds for setTimeout
             wifiClientSecure.setCACert(SystemGetCAcertificate());
             _mqttClient.setBufferSize(1024);
             _mqttClient.setServer(mqttConfig.mqttServer, mqttConfig.port);

--- a/src/ota/ota_module.cpp
+++ b/src/ota/ota_module.cpp
@@ -47,7 +47,8 @@ void checkUpdate()
 {
     systemLog(tINFO, "Checking for updates");
     DynamicJsonDocument versionJson(128);
-
+    
+    wifiClientSecure.stop();
     wifiClientSecure.setTimeout(12000 / 1000); // timeout argument is defined in seconds for setTimeout
 
     if (strlen(SystemGetGroupId()) == 0)
@@ -89,7 +90,9 @@ void checkUpdate()
         updatesHttpClient.end();
         systemLog(tERROR, "Cannot check for updates");
     }
-
+    
+    
+    wifiClientSecure.stop();
 }
 
 /**

--- a/src/ota/ota_module.cpp
+++ b/src/ota/ota_module.cpp
@@ -48,8 +48,8 @@ void checkUpdate()
     systemLog(tINFO, "Checking for updates");
     DynamicJsonDocument versionJson(128);
     
-    wifiClientSecure.setTimeout(12000 / 1000); // timeout argument is defined in seconds for setTimeout
-
+    wifiClientSecure.stop();
+    
     if (strlen(SystemGetGroupId()) == 0)
     { // Checking either this device is part of a group or a standalone device
         updatesHttpClient.begin(wifiClientSecure, OTA_CHECK_DEVICE_URL + String(SystemGetDeviceId()));
@@ -89,7 +89,9 @@ void checkUpdate()
         updatesHttpClient.end();
         systemLog(tERROR, "Cannot check for updates");
     }
-    
+
+    wifiClientSecure.stop();
+
 }
 
 /**

--- a/src/ota/ota_module.cpp
+++ b/src/ota/ota_module.cpp
@@ -47,8 +47,7 @@ void checkUpdate()
 {
     systemLog(tINFO, "Checking for updates");
     DynamicJsonDocument versionJson(128);
-    wifiClientSecure.stop();
-    wifiClientSecure.setCACert(SystemGetCAcertificate());
+
     wifiClientSecure.setTimeout(12000 / 1000); // timeout argument is defined in seconds for setTimeout
 
     if (strlen(SystemGetGroupId()) == 0)
@@ -91,8 +90,6 @@ void checkUpdate()
         systemLog(tERROR, "Cannot check for updates");
     }
 
-    wifiClientSecure.stop();
-    wifiClientSecure.setCACert( SystemGetCAcertificate());
 }
 
 /**

--- a/src/ota/ota_module.cpp
+++ b/src/ota/ota_module.cpp
@@ -48,7 +48,6 @@ void checkUpdate()
     systemLog(tINFO, "Checking for updates");
     DynamicJsonDocument versionJson(128);
     
-    wifiClientSecure.stop();
     wifiClientSecure.setTimeout(12000 / 1000); // timeout argument is defined in seconds for setTimeout
 
     if (strlen(SystemGetGroupId()) == 0)
@@ -91,8 +90,6 @@ void checkUpdate()
         systemLog(tERROR, "Cannot check for updates");
     }
     
-    
-    wifiClientSecure.stop();
 }
 
 /**


### PR DESCRIPTION
Removed Duplicate Certificate Loading.
Testing Criteria completed using the same main code, alternating library dependency master vs fork .

MQTT
- Cloud device Parameter Passed to IoTaap MQTT Instance.
- MQTT Subscription & Unsubscription to topics.
- Sending Unique Parameters to MQTT Instance.
- Receiving MQTT Payloads from MQTT Instance.
- Sending Payloads to devices topic & Events on IoTaap Console.

OTA
- Check for auto update forward revisioning to highest version.
- Check for auto update backward revisioning.
- Check for manual update forward revisioning.
- Check for manual update through 20 revisions. Note each runtime.

Notes:
Behaviour consistent when only the lines to set certificate removed.
When either `wifiClientSecure.stop();` lines are removed then unhandled exception occurs in a repeatable way.
Thus inability to perform the check update function.

Repeatable behaviour also discovered on hardware reset of connected device to create overflow on the uptime within console.

