### PR TITLE
Performance tuning

### DIFF
--- a/src/fs/fs_module.cpp
+++ b/src/fs/fs_module.cpp
@@ -21,7 +21,7 @@ static bool CheckDirStructure( void);
  */
 void initializeFileSystem()
 {
-    systemLog(tINFO, "Initializing filesystem");
+    systemLog(tSYSTEM, "Initializing filesystem");
     if (!SD.begin(SD_CS_PIN) || !CheckDirStructure())
     {
         systemStat.fsInitialized = false;
@@ -31,7 +31,7 @@ void initializeFileSystem()
     else
     {
         systemStat.fsInitialized = true;
-        systemLog(tINFO, "Filesystem initialized");
+        systemLog(tSYSTEM, "Filesystem initialized");
     }
 }
 

--- a/src/fs/sys_logs_data.cpp
+++ b/src/fs/sys_logs_data.cpp
@@ -209,6 +209,11 @@ void systemLog(logType type, const char *message)
         typeS = "INFO";
         break;
     }
+    case tSYSTEM:
+    {
+        typeS = "SYSTEM";
+        break;
+    }
     case tERROR:
     {
         typeS = "ERROR";
@@ -231,7 +236,10 @@ void systemLog(logType type, const char *message)
 
     sprintf(logBuff, "[%s] [%s] - %s", getSystemTimeString(Time), typeS, message);
     PrintDebugInfo(logBuff);
-    createFSlog(logBuff);
+    
+    if(type != tINFO){
+        createFSlog(logBuff);
+    }
 }
 
 

--- a/src/fs/sys_logs_data.h
+++ b/src/fs/sys_logs_data.h
@@ -5,6 +5,7 @@
 enum logType
 {
     tINFO = 0,
+    tSYSTEM,
     tERROR,
     tWARNING,
     tUSER

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -89,7 +89,7 @@ void connectToMqtt()
     xTaskCreate(
         MqttTask,
         "MqttProcess",
-        35000,
+        10000,
         NULL,
         1,
         &MqttHandler);

--- a/src/ota/ota_module.cpp
+++ b/src/ota/ota_module.cpp
@@ -45,7 +45,7 @@ void handleUpdates()
  */
 void checkUpdate()
 {
-    systemLog(tINFO, "Checking for updates");
+    systemLog(tSYSTEM, "Checking for updates");
     DynamicJsonDocument versionJson(128);
     
     wifiClientSecure.stop();
@@ -70,19 +70,19 @@ void checkUpdate()
 
         if (version != SystemGetFwVersion())
         {
-            systemLog(tINFO, "New update available!");
+            systemLog(tSYSTEM, "New update available!");
             otaUpdate();
         }
         else
         {
             updatesHttpClient.end();
-            systemLog(tINFO, "No new updates");
+            systemLog(tSYSTEM, "No new updates");
         }
     }
     else if (httpCode == 404)
     { // Not found return code
         updatesHttpClient.end();
-        systemLog(tINFO, "No firmware available");
+        systemLog(tSYSTEM, "No firmware available");
     }
     else
     {   //return code not identified
@@ -101,7 +101,7 @@ void checkUpdate()
  */
 void otaUpdate()
 {
-    systemLog(tINFO, "Starting update process...");
+    systemLog(tSYSTEM, "Starting update process...");
     systemStat.updateInProgress = true;
     t_httpUpdate_return ret;
     httpUpdate.setLedPin(LED1);
@@ -135,7 +135,7 @@ void otaUpdate()
         break;
 
     case HTTP_UPDATE_NO_UPDATES:
-        systemLog(tINFO, "No new updates available");
+        systemLog(tSYSTEM, "No new updates available");
         systemStat.updateInProgress = false;
         break;
 

--- a/src/system/definitions.h
+++ b/src/system/definitions.h
@@ -3,7 +3,7 @@
 
 /* GENERAL CONFIG */
 #define LIB_VERSION "3.0.3"
-#define STATUS_PUBLISH_TIME 1000 // How often system status is published in ms
+#define STATUS_PUBLISH_TIME 5000 // How often system status is published in ms
 #define OTA_CHECK_TIME 21600000 // Period in ms for checking for OTA updates
 #define CUSTOM_WDT_TIMEOUT 30 // Watchdog timeout in seconds
 #define WIFI_CONNECT_TIMEOUT 5  // WiFi timeout in seconds
@@ -11,11 +11,11 @@
 #define ARDUINOJSON_USE_LONG_LONG 1 // Using int64 variables in JSON
 
 /* QUEUE SIZES */
-#define LOGS_QUEUE_SIZE 30
-#define LOCAL_DATA_QUEUE_SIZE 30
+#define LOGS_QUEUE_SIZE 10
+#define LOCAL_DATA_QUEUE_SIZE 20
 #define SUBS_TOPIC_QUEUE_SIZE 10
 #define UNSUBS_TOPIC_QUEUE_SIZE 10
-#define MQTT_MESSAGES_QUEUE_SIZE 60
+#define MQTT_MESSAGES_QUEUE_SIZE 50
 
 /* PINS */
 #define BATSENS_PIN 36 // Battery voltage sensor pin

--- a/src/system/system_init.cpp
+++ b/src/system/system_init.cpp
@@ -37,10 +37,10 @@ void systemInfo()
 {
     char sysInfoBuff[512];
     sprintf(sysInfoBuff, "IoTaaP OS - v%s", SystemGetFwVersion());
-    systemLog(tINFO, sysInfoBuff);
+    systemLog(tSYSTEM, sysInfoBuff);
     sprintf(sysInfoBuff, "Core version: %s", LIB_VERSION);
-    systemLog(tINFO, sysInfoBuff);
+    systemLog(tSYSTEM, sysInfoBuff);
     sprintf(sysInfoBuff, "Device ID: %s", SystemGetDeviceId());
-    systemLog(tINFO, sysInfoBuff);
-    systemLog(tINFO, "I come in peace!");
+    systemLog(tSYSTEM, sysInfoBuff);
+    systemLog(tSYSTEM, "I come in peace!");
 }

--- a/src/system/system_tasks.cpp
+++ b/src/system/system_tasks.cpp
@@ -97,7 +97,7 @@ void SyncNTPtask(void *parameter)
             systemStat.systemTimeSynced = true;
             getLocalTime(&systemStat.systemTime);
             systemStat.bootTime = getSystemTimeMs();
-            systemLog(tINFO, "Synced system time with NTP");
+            systemLog(tSYSTEM, "Synced system time with NTP");
         }
         if (!WifiIsConnected() && systemStat.systemTimeSynced)
         {

--- a/src/wifi/wifi_module.cpp
+++ b/src/wifi/wifi_module.cpp
@@ -61,7 +61,7 @@ void wifiConnect( void)
     xTaskCreate(
         WiFiTask,
         "WiFiProcess",
-        10000,
+        15000,
         NULL,
         1,
         &WiFiHandler);


### PR DESCRIPTION
Improved overall system performance and stability:
- Changed Status publishing time to 5s (there is no need to publish status every second, and it consumes bandwidth)
- Changed Queue size (logs do not require big queue, lowered MQTT Messages queue to 50 and Local data to 20, gives enough data points even for fast systems)
- Reduced stack size for MqttTask to 10000 (tested, and it works fine, without memory issues)*
- Increased WiFiTask to 15000*
- Implemented **SYSTEM** log tag for crucial system information 
- Removed **INFO** tag logging to SD card (consumes a lot of time, memory, affects SD card, and it doesn't provide any helpful information), crucial system information is now logged with a **SYSTEM** tag

*_Task stack size_ - All task sizes should be tested and optimized before the next major release.